### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Build
+        run: bundle exec jekyll build --trace
+        env:
+          JEKYLL_ENV: production
+
+      - name: Validate HTML
+        run: bundle exec htmlproofer ./_site --disable-external --allow-missing-href --allow-hash-href

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ group :jekyll_plugins do
   gem 'jekyll-compose'
 end
 gem "webrick", "~> 1.8"
+gem "html-proofer", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (2.0.1)
     activesupport (8.1.2)
       base64
       bigdecimal
@@ -16,7 +17,15 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.9)
       public_suffix (>= 2.0.2, < 8.0)
+    afm (1.0.0)
+    async (2.39.0)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
+      metrics (~> 0.12)
+      traces (~> 0.18)
     base64 (0.3.0)
+    benchmark (0.5.0)
     bigdecimal (4.0.1)
     coffee-script (2.4.1)
       coffee-script-source
@@ -26,6 +35,10 @@ GEM
     commonmarker (0.23.12)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
+    console (1.35.1)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     csv (3.3.5)
     dnsruby (1.73.1)
       base64 (>= 0.2)
@@ -48,6 +61,10 @@ GEM
       net-http (~> 0.5)
     ffi (1.17.3-x64-mingw-ucrt)
     ffi (1.17.3-x86_64-linux-gnu)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (232)
@@ -102,15 +119,27 @@ GEM
       octokit (>= 4, < 8)
       public_suffix (>= 3.0, < 6.0)
       typhoeus (~> 1.3)
+    hashery (2.1.2)
     hawkins (2.0.5)
       em-websocket (~> 0.5)
       jekyll (~> 3.1)
     html-pipeline (2.14.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (5.2.1)
+      addressable (~> 2.3)
+      async (~> 2.1)
+      benchmark (~> 0.5)
+      nokogiri (~> 1.13)
+      pdf-reader (~> 2.11)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http_parser.rb (0.8.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    io-event (1.16.1)
     jekyll (3.10.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -235,6 +264,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     mercenary (0.3.6)
+    metrics (0.15.0)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
@@ -253,14 +283,22 @@ GEM
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    pdf-reader (2.15.1)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     prism (1.9.0)
     public_suffix (5.1.1)
     racc (1.8.1)
+    rainbow (3.1.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.4)
     rouge (3.30.0)
+    ruby-rc4 (0.1.5)
     rubyzip (2.4.1)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -275,6 +313,8 @@ GEM
     simpleidn (0.2.3)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    traces (0.18.2)
+    ttfunk (1.7.0)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
@@ -282,6 +322,8 @@ GEM
     unicode-display_width (1.8.0)
     uri (1.1.1)
     webrick (1.9.2)
+    yell (2.2.2)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   x64-mingw-ucrt
@@ -290,6 +332,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   hawkins
+  html-proofer (~> 5.0)
   jekyll-compose
   webrick (~> 1.8)
 

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ email: christianwilkie@gmail.com
 description: > # this means to ignore newlines until "baseurl:"
 #optional description
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://www.christianwilkie.com" # the base hostname & protocol for your site
+url: "https://www.christianwilkie.com" # the base hostname & protocol for your site
 mastodon_instance: fosstodon.org
 mastodon_username: ChristianWilkie
 github_username:  ChristianWilkie

--- a/_posts/2014-12-20-setting-up-a-free-website-using-jekyll-and-github-pages.md
+++ b/_posts/2014-12-20-setting-up-a-free-website-using-jekyll-and-github-pages.md
@@ -6,8 +6,8 @@ date:   2014-12-20 22:18:00
 Recently I was able to cut down on some of my site hosting costs by moving to [GitHub Pages](https://pages.github.com/),
 a free way to host public websites of static content. It won't work for something like WordPress where you need to run
 something server side, but it works great for plain .HTML pages for instance. Also, by using
-[Jekyll](http://jekyllrb.com/) you can dynamically generate static .HTML pages for your site, allowing you to do some
-cool stuff like generate blog posts from [easy-to-write markdown](http://daringfireball.net/projects/markdown/syntax)
+[Jekyll](https://jekyllrb.com/) you can dynamically generate static .HTML pages for your site, allowing you to do some
+cool stuff like generate blog posts from [easy-to-write markdown](https://daringfireball.net/projects/markdown/syntax)
 files.
 
 [Here's how you can get started with your own GitHub site](https://help.github.com/articles/using-jekyll-with-pages/),
@@ -42,5 +42,5 @@ username as needed.
 Your site should then appear on GitHub at `http://username.github.io` after a short time (maybe 10-15 minutes for it
 to be generated for the first time).
 
-To learn more about using Jekyll itself, check out the [official Jekyll site](http://jekyllrb.com/), and especially the
- subpage on [writing posts](http://jekyllrb.com/docs/posts/).
+To learn more about using Jekyll itself, check out the [official Jekyll site](https://jekyllrb.com/), and especially the
+ subpage on [writing posts](https://jekyllrb.com/docs/posts/).

--- a/about.md
+++ b/about.md
@@ -9,8 +9,8 @@ permalink: /about/
     	<a href="../assets/wilkieresume20220113.pdf">Resume (PDF)</a>
     </div>
     <div>
-        <a href="http://stackoverflow.com/users/657205/christian-wilkie">
-    <img src="http://stackoverflow.com/users/flair/657205.png" width="208" height="58" alt="profile for Christian Wilkie at Stack Overflow, Q&amp;A for professional and enthusiast programmers" title="profile for Christian Wilkie at Stack Overflow, Q&amp;A for professional and enthusiast programmers">
+        <a href="https://stackoverflow.com/users/657205/christian-wilkie">
+    <img src="https://stackoverflow.com/users/flair/657205.png" width="208" height="58" alt="profile for Christian Wilkie at Stack Overflow, Q&amp;A for professional and enthusiast programmers" title="profile for Christian Wilkie at Stack Overflow, Q&amp;A for professional and enthusiast programmers">
     </a>
     </div>
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that runs on every push to `master` and all pull requests
- Builds the site with `bundle exec jekyll build --trace` (`JEKYLL_ENV=production`)
- Validates the built `_site/` with html-proofer (internal links only, `--disable-external`)
- Adds `html-proofer ~> 5.0` to `Gemfile` / `Gemfile.lock`
- Fixes pre-existing `http://` URLs surfaced by htmlproofer's enforce-https check:
  - `_config.yml`: site `url` updated to `https://` (fixes canonical/feed links on every page)
  - `about.md`: Stack Overflow link and flair image updated to `https://`
  - 2014 post: `jekyllrb.com` and `daringfireball.net` links updated to `https://`

The main goal is a green/red check on Dependabot PRs so dependency bumps can be verified without breaking the build. GitHub Pages deployment is unchanged.

## Test plan

- [ ] CI run on this PR passes (build + htmlproofer steps both green)
- [ ] Merge to master; confirm the push trigger also goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)